### PR TITLE
Requests requirement fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,12 @@ setup(
         "Programming Language :: Python :: 3.5",
     ],
     install_requires=[
-        'requests',
+        'requests>=2.5,<3',
         'requests_mock',
         'unittest2'
     ],
     setup_requires=[
-        'requests',
+        'requests>=2.5,<3',
         'requests_mock',
         'unittest2'
     ],


### PR DESCRIPTION
Simply requiring `requests` is failing against PyPi, so let's use a specific version
