### PR TITLE
Remove Python 2.6 from the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"


### PR DESCRIPTION
Python 2.6 went EOL in 2013 and recently is no longer supported by flake8. This makes it prohibitively time consuming to continue to actively support.
